### PR TITLE
Feature: Parametrizar tiempo entre publicaciones

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,7 +1,7 @@
 import 'regenerator-runtime/runtime';
 import TwitterApi, { ETwitterStreamEvent, TweetV1 } from 'twitter-api-v2';
 import { generateImage } from './image-generator';
-import { getCard } from './cards';
+import {Card, getCard} from './cards';
 const config = require('./config');
 
 const client = new TwitterApi(config.environment);
@@ -13,8 +13,10 @@ const setupStream = async () => {
 };
 
 const uploadMedia = async (): Promise<string[]> => {
+  const card: Card = getCard();
+  console.log(`Twitted strategy ${card.id}: ${card.quote}`);
   const bufferedImage: string | Buffer | (string | Buffer)[] =
-    await generateImage(getCard());
+    await generateImage(card);
   return await Promise.all([
     client.v1.uploadMedia(bufferedImage as Buffer, { type: 'png' }),
   ]);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -2,8 +2,9 @@ import 'regenerator-runtime/runtime';
 import TwitterApi, { ETwitterStreamEvent, TweetV1 } from 'twitter-api-v2';
 import { generateImage } from './image-generator';
 import { getCard } from './cards';
+const config = require('./config');
 
-const client = new TwitterApi(require('./config'));
+const client = new TwitterApi(config.environment);
 let stream;
 
 const setupStream = async () => {
@@ -40,4 +41,4 @@ const tweetCard = async (tweet?: TweetV1) => {
 
 void tweetCard();
 void setupStream();
-setInterval(tweetCard, 1000 * 60 * 60 * 24);
+setInterval(tweetCard, 1000 * 60 * 60 * config.postIntervalInHours);

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,4 +8,6 @@ const environment = {
   accessSecret: process.env.access_token_secret,
 };
 
-module.exports = environment;
+const postIntervalInHours: number = parseInt(process.env.post_interval_in_hours);
+
+module.exports = { environment, postIntervalInHours };

--- a/src/image-generator.ts
+++ b/src/image-generator.ts
@@ -12,8 +12,6 @@ const backgroundImages = [
   path.join(__dirname, '/assets/background4.jpg'),
 ];
 
-console.log(backgroundImages);
-
 const style = (rotation: string) => `
             <style>
               @font-face {


### PR DESCRIPTION
# Detalles
* Agregada variable de entorno `post_interval_in_hours` para configurar intervalo, en horas, entre publicaciones. Si la variable no se encuentra configurada, se asigna el intervlao estándar de 24 horas.
* Agregado log de tarjeta publicada previo a subir el tuit.
* Actualizado README.md con el detalle de la nueva variable de entorno.

# Otros cambios
* Limpieza de console.log innecesarios (ubicación de imágenes de background).