### PR TITLE
[#25] - CronJob en reemplazo de setInterval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "copyfiles": "^2.4.1",
+        "cron": "^3.3.0",
         "dotenv": "^9.0.2",
         "node-html-to-image": "^4.0.0",
         "path": "^0.12.7",
@@ -23,6 +24,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-typescript": "^7.12.7",
         "@babel/register": "^7.12.10",
+        "@types/cron": "^2.4.3",
         "@types/node": "^14.14.16",
         "@types/puppeteer": "^5.4.3",
         "@typescript-eslint/eslint-plugin": "^5.26.0",
@@ -2040,6 +2042,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/cron": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.4.3.tgz",
+      "integrity": "sha512-ViRBkoZD9Rk0hGeMdd2GHGaOaZuH9mDmwsE5/Zo53Ftwcvh7h9VJc8lIt2wdgEwS4EW5lbtTX6vlE0idCLPOyA==",
+      "deprecated": "This is a stub types definition. cron provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "cron": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2051,6 +2063,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
     },
     "node_modules/@types/node": {
       "version": "14.18.18",
@@ -3041,6 +3058,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cron": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.3.0.tgz",
+      "integrity": "sha512-uwRMLudSn2vPPjg392dKOm3KoJRw/eOOFtcHbrmRJxCd/NDF3187JVnajTvHPIlam0UwhKUZWwVPd1V5vBlmsw==",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
@@ -5372,6 +5398,14 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
       "engines": {
         "node": ">=12"
       }
@@ -8886,6 +8920,15 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "@types/cron": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.4.3.tgz",
+      "integrity": "sha512-ViRBkoZD9Rk0hGeMdd2GHGaOaZuH9mDmwsE5/Zo53Ftwcvh7h9VJc8lIt2wdgEwS4EW5lbtTX6vlE0idCLPOyA==",
+      "dev": true,
+      "requires": {
+        "cron": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -8897,6 +8940,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
     },
     "@types/node": {
       "version": "14.18.18",
@@ -9576,6 +9624,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cron": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.3.0.tgz",
+      "integrity": "sha512-uwRMLudSn2vPPjg392dKOm3KoJRw/eOOFtcHbrmRJxCd/NDF3187JVnajTvHPIlam0UwhKUZWwVPd1V5vBlmsw==",
+      "requires": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
+      }
     },
     "cross-fetch": {
       "version": "4.0.0",
@@ -11269,6 +11326,11 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+    },
+    "luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
     "@babel/register": "^7.12.10",
+    "@types/cron": "^2.4.3",
     "@types/node": "^14.14.16",
     "@types/puppeteer": "^5.4.3",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
@@ -56,6 +57,7 @@
   },
   "dependencies": {
     "copyfiles": "^2.4.1",
+    "cron": "^3.3.0",
     "dotenv": "^9.0.2",
     "node-html-to-image": "^4.0.0",
     "path": "^0.12.7",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,6 +3,7 @@ import TwitterApi, { TweetV1 } from 'twitter-api-v2';
 import { generateImage } from './image-generator';
 import { Card, getCard } from './cards';
 import { config } from './config';
+import { CronJob } from 'cron';
 
 const client = new TwitterApi(config.environment);
 
@@ -43,7 +44,12 @@ const tweetCard = async (tweet?: TweetV1) => {
   }
 };
 
-const oneHourInMilliseconds = 1000 * 60 * 60;
-
-void tweetCard();
-setInterval(tweetCard, oneHourInMilliseconds * config.postIntervalInHours);
+new CronJob(
+  '30 10 * * *',
+  async function () {
+    await tweetCard();
+  },
+  null,
+  true,
+  'America/Argentina/Buenos_Aires',
+);


### PR DESCRIPTION
## Resumen
- Se agregan los paquetes `cron` y `@types/cron`.
- Se reemplaza la implementación de la subida de una tarjeta vía setInterval por el uso de un CronJob que se ejecuta todos los días a las 10:30 AM, hora de Argentina.